### PR TITLE
Fix to evil alts jungle grass not spreading properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+# Rider files
+.idea
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/AltLibrary.csproj
+++ b/AltLibrary.csproj
@@ -7,13 +7,14 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DotNetName Condition=" '$(OS)' == 'Unix' ">/usr/bin/dotnet</DotNetName>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FargoSeeds">
-      <HintPath>..\ModAssemblies\FargoSeeds_v0.5.2.dll</HintPath>
+      <HintPath>..\ModAssemblies\FargoSeeds_v0.5.3.dll</HintPath>
     </Reference>
     <Reference Include="PegasusLib">
-      <HintPath>..\ModAssemblies\PegasusLib_v1.0.6.dll</HintPath>
+      <HintPath>..\ModAssemblies\PegasusLib_v1.0.7.2.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Common/AltBiomes/AltBiome.cs
+++ b/Common/AltBiomes/AltBiome.cs
@@ -134,7 +134,7 @@ namespace AltLibrary.Common.AltBiomes {
 		/// </summary>
 		public int? BiomeMud = null;
 		/// <summary>
-		/// For Jungle alts.
+		/// For Jungle and evil alts, since vanilla introduced evil jungle grass. 
 		/// </summary>
 		public int? BiomeJungleGrass = null;
 		/// <summary>

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,16 +1,16 @@
 {
-  "profiles": {
-    "Terraria": {
-      "commandName": "Executable",
-      "executablePath": "dotnet",
-      "commandLineArgs": "$(tMLPath)",
-      "workingDirectory": "$(tMLSteamPath)"
-    },
-    "TerrariaServer": {
-      "commandName": "Executable",
-      "executablePath": "dotnet",
-      "commandLineArgs": "$(tMLServerPath)",
-      "workingDirectory": "$(tMLSteamPath)"
-    }
-  }
+	"profiles": {
+		"Terraria": {
+			"commandName": "Executable",
+			"executablePath": "$(DotNetName)",
+			"commandLineArgs": "$(tMLPath)",
+			"workingDirectory": "$(tMLSteamPath)"
+		},
+		"TerrariaServer": {
+			"commandName": "Executable",
+			"executablePath": "$(DotNetName)",
+			"commandLineArgs": "$(tMLServerPath)",
+			"workingDirectory": "$(tMLSteamPath)"
+		}
+	}
 }


### PR DESCRIPTION
This PR makes evil alts use the AltBiome BiomeJungleGrass property to correctly spread evil grass to adjacent blocks according to vanilla behaviour, which I tested in-game.
evil dirt grass -> empty mud blocks = evil jungle grass
evil jungle grass -> empty mud blocks = evil jungle grass
evil jungle grass -> empty dirt OR dirt grass blocks = evil dirt grass

Besides that it only includes updates to the dlls and some conditions to allow me to build and run the mod in the Rider IDE on Linux, which doesn't interfere with Windows/VSComm/VSCode users. 